### PR TITLE
add cc license to notebook

### DIFF
--- a/notebooks/ontology/NCI Thesaurus to CDISC PFB example.ipynb
+++ b/notebooks/ontology/NCI Thesaurus to CDISC PFB example.ipynb
@@ -559,7 +559,9 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -607,6 +609,13 @@
     "    writer.copy_schema(reader)\n",
     "\n",
     "writer.write(pfbJSON._from_json(writer.metadata, \"./bdc-sample\", \"DEV\", \"TEST\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook uses the Attribution 2.0 Generic (CC BY 2.0) license https://creativecommons.org/licenses/by/2.0/legalcode"
    ]
   }
  ],


### PR DESCRIPTION
### Improvements
adding Attribution 2.0 Generic (CC BY 2.0) license to notebook
